### PR TITLE
Replace `gcc` invocation with `g++`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 a.exe: main.o
-	gcc -o a.exe main.o -lstdc++ -std=c++11
+	g++ -o a.exe main.o -lstdc++ -std=c++11
 
 main.o : main.cpp BloomFilter.hpp
-	gcc -c main.cpp -lstdc++ -std=c++11
+	g++ -c main.cpp -lstdc++ -std=c++11
 
 run: a.exe
 	a.exe


### PR DESCRIPTION
The default Makefile results in the following error upon building (tested on Debian Stretch with `g++ 6.3.0-6`):

```
BloomFilter (master *) $ make
gcc -c main.cpp -lstdc++ -std=c++11
gcc -o a.exe main.o -lstdc++ -std=c++11
/usr/bin/ld: main.o: undefined reference to symbol 'expf@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libm.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
Makefile:2: recipe for target 'a.exe' failed
make: *** [a.exe] Error 1
```
This can be fixed by replacing the `gcc` invocation with `g++` to link `libstdc++` correctly (which I understand, includes `libm`). This patch does the same.